### PR TITLE
fix hmatrix cabal file so it works correctly

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -35,6 +35,7 @@ extra-source-files: src/C/lapack-aux.h
 flag openblas
     description:    Link with OpenBLAS (https://github.com/xianyi/OpenBLAS) optimized libraries.
     default:        False
+    manual: True 
 
 library
 


### PR DESCRIPTION
currently the cabal file assumes unconditionally that openblas flag is true on random users, this fixes it and makes -fopenblas opt in. 

please make a bug fix release with this post haste!

and/or give me permission to use my hackage trustee powers to fix this on the current hackage release, and i'll do it there too