### PR TITLE
GHC 7.11: cannot deduce Fractional and Element instances

### DIFF
--- a/packages/base/src/Data/Packed/Internal/Numeric.hs
+++ b/packages/base/src/Data/Packed/Internal/Numeric.hs
@@ -241,7 +241,7 @@ instance Container Vector (Complex Float)
 
 ---------------------------------------------------------------
 
-instance (Container Vector a) => Container Matrix a
+instance (Fractional a, Element a, Container Vector a) => Container Matrix a
   where
     size' = size
     scale' x = liftMatrix (scale' x)


### PR DESCRIPTION
Installing the latest `master` with GHC 7.11 gives the following error:

    src/Data/Packed/Internal/Numeric.hs:244:10:
        Could not deduce (Fractional a)
          arising from the superclasses of an instance declaration
        from the context: Container Vector a
          bound by the instance declaration
          at src/Data/Packed/Internal/Numeric.hs:244:10-51
        Possible fix:
          add (Fractional a) to the context of the instance declaration
        In the instance declaration for ‘Container Matrix a’

    src/Data/Packed/Internal/Numeric.hs:244:10:
        Could not deduce (Element a)
          arising from the superclasses of an instance declaration
        from the context: Container Vector a
          bound by the instance declaration
          at src/Data/Packed/Internal/Numeric.hs:244:10-51
        Possible fix:
          add (Element a) to the context of the instance declaration
        In the instance declaration for ‘Container Matrix a’
    cabal: Error: some packages failed to install:
    hmatrix-0.16.1.3 failed during the building phase. The exception was:
    ExitFailure 1

This PR is a naive fix for those errors, please have a look.

Extra system info:

    λ:  ghc --version
    The Glorious Glasgow Haskell Compilation System, version 7.11.20150227

    λ:  cabal --version
    cabal-install version 1.22.0.0
    using version 1.22.0.0 of the Cabal library 
