### PR TITLE
In C99 int32_t is from stdint.h

### DIFF
--- a/packages/base/src/C/vector-aux.c
+++ b/packages/base/src/C/vector-aux.c
@@ -13,6 +13,7 @@ typedef float  complex TCF;
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #define MACRO(B) do {B} while (0)
 #define ERROR(CODE) MACRO(return CODE;)


### PR DESCRIPTION
A windows user was complaining about this issue on IRC today, so here's
a patch.