### PR TITLE
Fix copy-paste error in interpolation module

### DIFF
--- a/packages/gsl/src/Numeric/GSL/Interpolation.hs
+++ b/packages/gsl/src/Numeric/GSL/Interpolation.hs
@@ -117,7 +117,7 @@ evaluate :: InterpolationMethod    -- ^ What method to use to interpolate
             -> Double              -- ^ Point at which to evaluate the function
             -> Double              -- ^ Interpolated result
 evaluate mth pts =
-  applyCFun "evaluate" "spline_eval" c_spline_eval_deriv
+  applyCFun "evaluate" "spline_eval" c_spline_eval
   mth (fromList xs) (fromList ys)
   where
     (xs, ys) = unzip pts


### PR DESCRIPTION
It turns out I made a horrible mistake when preparing the original patch, and I never did a final run of my doctest examples.  

This patch makes `Numeric.GSL.Interpolation.evaluate` call GSL's `gsl_spline_eval` rather than `gsl_spline_eval_deriv`.

This is super embarrassing; I'm sorry!