### PR TITLE
Possible fix for #141

### DIFF
--- a/packages/base/src/Internal/C/lapack-aux.c
+++ b/packages/base/src/Internal/C/lapack-aux.c
@@ -55,10 +55,6 @@ typedef float  complex TCF;
 #define NODEFPOS 2006
 #define NOSPRTD  2007
 
-inline int mod (int a, int b);
-
-inline int64_t mod_l (int64_t a, int64_t b);
-
 ////////////////////////////////////////////////////////////////////////////////
 void asm_finit() {
 #ifdef i386
@@ -247,7 +243,7 @@ int svd_l_C(OCMAT(a),OCMAT(u), DVEC(s),OCMAT(v)) {
             ldvt = q;
         }
     }DEBUGMSG("svd_l_C");
-    
+
     double *rwork = (double*) malloc(5*q*sizeof(double));
     CHECK(!rwork,MEM);
     integer lwork = -1;
@@ -423,7 +419,7 @@ int eig_l_R(ODMAT(a),ODMAT(u), CVEC(s),ODMAT(v)) {
 //////////////////// symmetric real eigensystem ////////////
 
 int dsyev_(char *jobz, char *uplo, integer *n, doublereal *a,
-	 integer *lda, doublereal *w, doublereal *work, integer *lwork,
+	integer *lda, doublereal *w, doublereal *work, integer *lwork,
 	integer *info);
 
 int eig_l_S(int wantV,DVEC(s),ODMAT(v)) {
@@ -665,7 +661,7 @@ int linearSolveLSC_l(OCMAT(a),OCMAT(b)) {
 int dgelss_(integer *m, integer *n, integer *nrhs,
 	doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *
 	s, doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
-	 integer *info);
+	integer *info);
 
 int linearSolveSVDR_l(double rcond,ODMAT(a),ODMAT(b)) {
     integer m = ar;
@@ -955,7 +951,7 @@ int schur_l_R(ODMAT(u), ODMAT(s)) {
 int zgees_(char *jobvs, char *sort, L_fp select, integer *n,
 	doublecomplex *a, integer *lda, integer *sdim, doublecomplex *w,
 	doublecomplex *vs, integer *ldvs, doublecomplex *work, integer *lwork,
-	 doublereal *rwork, logical *bwork, integer *info);
+	doublereal *rwork, logical *bwork, integer *info);
 
 int schur_l_C(OCMAT(u), OCMAT(s)) {
     integer m = sr;

--- a/packages/base/src/Internal/C/lapack-aux.h
+++ b/packages/base/src/Internal/C/lapack-aux.h
@@ -88,3 +88,24 @@ typedef short ftnlen;
 #define AT(m,i,j) (m##p[(i)*m##Xr + (j)*m##Xc])
 #define TRAV(m,i,j) int i,j; for (i=0;i<m##r;i++) for (j=0;j<m##c;j++)
 
+/********************************************************/
+
+inline
+int mod (int a, int b) {
+    int m = a % b;
+    if (b>0) {
+        return m >=0 ? m : m+b;
+    } else {
+        return m <=0 ? m : m+b;
+    }
+}
+
+inline
+int64_t mod_l (int64_t a, int64_t b) {
+    int64_t m = a % b;
+    if (b>0) {
+        return m >=0 ? m : m+b;
+    } else {
+        return m <=0 ? m : m+b;
+    }
+}

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -716,16 +716,6 @@ int mapValF(int code, float* pval, KFVEC(x), FVEC(r)) {
     }
 }
 
-inline
-int mod (int a, int b) {
-    int m = a % b;
-    if (b>0) {
-        return m >=0 ? m : m+b;
-    } else {
-        return m <=0 ? m : m+b;
-    }
-}
-
 int mapValI(int code, int* pval, KIVEC(x), IVEC(r)) {
     int k;
     int val = *pval;
@@ -739,16 +729,6 @@ int mapValI(int code, int* pval, KIVEC(x), IVEC(r)) {
         OPV(6,mod(val,xp[k]))
         OPV(7,mod(xp[k],val))
         default: ERROR(BAD_CODE);
-    }
-}
-
-inline
-int64_t mod_l (int64_t a, int64_t b) {
-    int64_t m = a % b;
-    if (b>0) {
-        return m >=0 ? m : m+b;
-    } else {
-        return m <=0 ? m : m+b;
     }
 }
 


### PR DESCRIPTION
Move definitions of ``mod``/``mod_l`` to ``lapack-aux.h``, where they can be directly seen by ``lapack-aux.c`` and ``vector-aux.c``. Compiler-dependant interpretations of ``inline`` are thus avoided. Works for me!

Some relevant discussions:
http://stackoverflow.com/questions/6312597/is-inline-without-static-or-extern-ever-useful-in-c99/6312854
http://stackoverflow.com/questions/216510/extern-inline/216546
http://stackoverflow.com/questions/16245521/c99-inline-function-in-c-file/16245669