### PR TITLE
Currently OpenBLAS building on Windows is not working.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,6 +55,11 @@ using this method.
 
 [winpack]: https://github.com/downloads/AlbertoRuiz/hmatrix/gsl-lapack-windows.zip
 
+### Alternative Windows build
+1) > cabal update
+2) Download and unzip somewhere OpenBLAS http://www.openblas.net/
+3) > cabal install --flags=openblas --extra-lib-dirs=C:\...\OpenBLAS\lib --extra-include-dir=C:\...\OpenBLAS\include
+
 ## Tests ###############################################
 
 After installation we can verify that the library works as expected:

--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -96,13 +96,13 @@ library
 
     cpp-options:        -DBINARY
 
-    if flag(openblas)
-        extra-lib-dirs:     /usr/lib/openblas/lib
-        extra-libraries:    openblas
-    else
-        extra-libraries:    blas lapack
-
     if os(OSX)
+        if flag(openblas)
+            extra-lib-dirs:     /opt/local/lib/openblas/lib
+            extra-libraries:    openblas
+        else
+            extra-libraries:    blas lapack
+
         extra-lib-dirs: /opt/local/lib/
         include-dirs: /opt/local/include/
         extra-lib-dirs: /usr/local/lib/
@@ -112,14 +112,29 @@ library
         frameworks: Accelerate
 
     if os(freebsd)
+        if flag(openblas)
+            extra-lib-dirs:     /usr/local/lib/openblas/lib
+            extra-libraries:    openblas
+        else
+            extra-libraries:    blas lapack
+
        extra-lib-dirs: /usr/local/lib
        include-dirs: /usr/local/include
-       extra-libraries: blas lapack gfortran
+       extra-libraries: gfortran
 
     if os(windows)
-        extra-libraries: blas lapack
+        if flag(openblas)
+            extra-libraries:    libopenblas
+        else
+            extra-libraries:    blas lapack
 
     if os(linux)
+        if flag(openblas)
+            extra-lib-dirs:     /usr/lib/openblas/lib
+            extra-libraries:    openblas
+        else
+            extra-libraries:    blas lapack
+
         if arch(x86_64)
             cc-options: -fPIC
 


### PR DESCRIPTION
1. Under Windows actual name of the library is libopenblas.dll and not openblas.dll
2. There were duplication of external dependencies: blas and lapack. Because extra-libraries was declared twice - for openstack condition and for OS condition.
3. I'm not sure how OpenBLAS is built on other OSes, so someone have to check this change on other OSes.

There are still problems left:
src\Internal\C\vector-aux.c:1010:30:
     warning: 'struct random_data' declared inside parameter list [enabled by default]

src\Internal\C\vector-aux.c:1010:30:
     warning: its scope is only this definition or declaration, which is probably not what you want [enabled by default]
src\Internal\C\vector-aux.c: In function 'urandom':

src\Internal\C\vector-aux.c:1012:5:
     warning: implicit declaration of function 'random_r' [-Wimplicit-function-declaration]
src\Internal\C\vector-aux.c: At top level:

src\Internal\C\vector-aux.c:1019:18:
     warning: 'struct random_data' declared inside parameter list [enabled by default]
src\Internal\C\vector-aux.c: In function 'gaussrand':

src\Internal\C\vector-aux.c:1026:13:
     warning: passing argument 1 of 'urandom' from incompatible pointer type [enabled by default]

src\Internal\C\vector-aux.c:1010:15:
     note: expected 'struct random_data *' but argument is of type 'struct random_data *'

src\Internal\C\vector-aux.c:1027:4:
     warning: passing argument 1 of 'urandom' from incompatible pointer type [enabled by default]

src\Internal\C\vector-aux.c:1010:15:
     note: expected 'struct random_data *' but argument is of type 'struct random_data *'
src\Internal\C\vector-aux.c: In function 'random_vector':

src\Internal\C\vector-aux.c:1046:24:
     error: storage size of 'buffer' isn't known

src\Internal\C\vector-aux.c:1048:31:
     error: invalid application of 'sizeof' to incomplete type 'struct random_data'

src\Internal\C\vector-aux.c:1051:5:
     warning: implicit declaration of function 'initstate_r' [-Wimplicit-function-declaration]

src\Internal\C\vector-aux.c:1046:24:
     warning: unused variable 'buffer' [-Wunused-variable]
cabal: Error: some packages failed to install:
hmatrix-0.17.0.0 failed during the building phase. The exception was:
ExitFailure 1