### PR TITLE
Stack build configuration for resolver LTS 3.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,25 +57,29 @@ using this method.
 
 ### Alternative Windows build
 
-1) > cabal update
+1) 
+
+	> cabal update
 
 2) Download and unzip somewhere OpenBLAS http://www.openblas.net/
 
 3) In a normal Windows cmd:
 
-     > cabal install --flags=openblas --extra-lib-dirs=C:\...\OpenBLAS\lib --extra-include-dir=C:\...\OpenBLAS\include
+    > cabal install --flags=openblas --extra-lib-dirs=C:\...\OpenBLAS\lib --extra-include-dir=C:\...\OpenBLAS\include
 
 ### Stack-based Windows build
 
-1) > cd packages\base
+Similar should be build under other OSes, like Linux and OSX.
 
-1) > stack setup
+1) 
+
+	> stack setup
 
 2) Download and unzip somewhere OpenBLAS http://www.openblas.net/
 
-3) In a normal Windows cmd:
+3) Example in a normal Windows cmd for building hmatrix base lib:
 
-     > stack install --flag hmatrix:openblas --extra-lib-dirs=C:\...\OpenBLAS\lib --extra-include-dir=C:\...\OpenBLAS\include
+     > stack install hmatrix --flag hmatrix:openblas --extra-lib-dirs=C:\...\OpenBLAS\lib --extra-include-dir=C:\...\OpenBLAS\include
 	 
 ## Tests ###############################################
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,18 @@
+flags:
+  hmatrix-special:
+    safe-cheap: false
+  hmatrix-tests:
+    gsl: true
+  hmatrix:
+    openblas: false
+  hmatrix-gsl:
+    onlygsl: false
+packages:
+- packages\tests\
+- packages\special\
+- packages\sparse\
+- packages\gsl\
+- packages\glpk\
+- packages\base\
+extra-deps: []
+resolver: lts-3.3


### PR DESCRIPTION
Stack configuration in root folder for building of other libraries as well. It should work under Linux and OSX, too. But I'm tested it only under Windows 10 x64.