### PR TITLE
Fixed missing "__muldc3" symbol when building with OpenBLAS under Windows.

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -124,7 +124,7 @@ library
 
     if os(windows)
         if flag(openblas)
-            extra-libraries:    libopenblas
+            extra-libraries:    libopenblas, libgcc_s_seh-1, libgfortran-3, libquadmath-0
         else
             extra-libraries:    blas lapack
 


### PR DESCRIPTION
Added some missing dependent DLLs for OpenBLAS linkage.
This is related to missing "__muldc3" symbol.
This fix doesn't solve all Windows problems. Next one is with missing "atanh" symbol related to math.h functions and GCC.