### PR TITLE
meanCov type update to use Herm instead of Matrix

### DIFF
--- a/packages/base/src/Internal/Container.hs
+++ b/packages/base/src/Internal/Container.hs
@@ -28,7 +28,7 @@ import Internal.Vector
 import Internal.Matrix
 import Internal.Element
 import Internal.Numeric
-import Internal.Algorithms(Field,linearSolveSVD)
+import Internal.Algorithms(Field,linearSolveSVD,Herm,mTm)
 
 ------------------------------------------------------------------
 
@@ -206,14 +206,14 @@ optimiseMult = mconcat
  , -1.0127225830525157e-2,     3.0373954915729318 ])
 
 -}
-meanCov :: Matrix Double -> (Vector Double, Matrix Double)
+meanCov :: Matrix Double -> (Vector Double, Herm Double)
 meanCov x = (med,cov) where
     r    = rows x
     k    = 1 / fromIntegral r
     med  = konst k r `vXm` x
     meds = konst 1 r `outer` med
     xc   = x `sub` meds
-    cov  = scale (recip (fromIntegral (r-1))) (trans xc `mXm` xc)
+    cov  = scale (recip (fromIntegral (r-1))) (mTm xc)
 
 --------------------------------------------------------------------------------
 
@@ -293,5 +293,3 @@ remap i j m
     | otherwise = error $ "out of range index in remap"
   where
     [i',j'] = conformMs [i,j]
-    
-

--- a/packages/gsl/src/Numeric/GSL/Random.hs
+++ b/packages/gsl/src/Numeric/GSL/Random.hs
@@ -39,13 +39,13 @@ type Seed = Int
 gaussianSample :: Seed
                -> Int -- ^ number of rows
                -> Vector Double -- ^ mean vector
-               -> Matrix Double -- ^ covariance matrix
+               -> Herm   Double -- ^ covariance matrix
                -> Matrix Double -- ^ result
 gaussianSample seed n med cov = m where
     c = size med
     meds = konst 1 n `outer` med
     rs = reshape c $ randomVector seed Gaussian (c * n)
-    m = rs <> cholSH cov + meds
+    m = rs <> chol cov + meds
 
 -- | Obtains a matrix whose rows are pseudorandom samples from a multivariate
 -- uniform distribution.
@@ -87,4 +87,3 @@ rand = randm Uniform
 -}
 randn :: Int -> Int -> IO (Matrix Double)
 randn = randm Gaussian
-

--- a/packages/tests/src/Numeric/LinearAlgebra/Tests.hs
+++ b/packages/tests/src/Numeric/LinearAlgebra/Tests.hs
@@ -137,7 +137,7 @@ randomTestGaussian = c :~1~: snd (meanCov dat) where
                 2,4,0,
                -2,2,1]
     m = 3 |> [1,2,3]
-    c = a <> tr a
+    c = mTm a
     dat = gaussianSample 7 (10^6) m c
 
 randomTestUniform = c :~1~: snd (meanCov dat) where
@@ -944,5 +944,3 @@ luBench_2 = do
     luBenchN_2 luSolve' luPacked' 500 (5::R)          "luSolve'.luPacked' Double    "
     luBenchN_2 luSolve' luPacked' 500 (5::Mod 9973 I) "luSolve'.luPacked' I mod 9973"
     luBenchN_2 luSolve' luPacked' 500 (5::Mod 9973 Z) "luSolve'.luPacked' Z mod 9973"
-
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,11 +8,11 @@ flags:
   hmatrix-gsl:
     onlygsl: false
 packages:
-- packages\tests\
-- packages\special\
-- packages\sparse\
-- packages\gsl\
-- packages\glpk\
-- packages\base\
+- packages/tests/
+- packages/special/
+- packages/sparse/
+- packages/gsl/
+- packages/glpk/
+- packages/base/
 extra-deps: []
 resolver: lts-3.3


### PR DESCRIPTION
The two first commits are the changes to meanCov, testing code and generator code. The third commit is an unrelated change to the top level stack.yaml (replacing backslash by slash as direcory separator).

I have not managed to build the full set of packages due to some configuration problem ("Missing C libraries: mkl_intel, mkl_sequential, mkl_core") so there may even still be some type error.

Feel free to use any subset of the patches as you see fit.
/Patrik
