### PR TITLE
A workaround for linker errors on Windows

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -31,6 +31,11 @@ flag openblas
     default:        False
     manual: True
 
+flag windowshack
+    description:    Disable some functions from vector_aux.c to prevent linker errors on Windows
+    default:        False
+    manual:         True
+
 library
 
     Build-Depends:      base >= 4.8 && < 5,
@@ -95,6 +100,8 @@ library
         cc-options:     -msse2
 
     cpp-options:        -DBINARY
+    if flag(windowshack)
+      cpp-options: -DWINDOWS_LINKER_HACK
 
     if os(OSX)
         if flag(openblas)

--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -93,6 +93,8 @@ library
                         -fprof-auto
 
     cc-options:         -O4 -Wall
+    if flag(windowshack)
+      cc-options: -DWINDOWS_LINKER_HACK
 
     if arch(x86_64)
         cc-options:     -msse2
@@ -100,8 +102,6 @@ library
         cc-options:     -msse2
 
     cpp-options:        -DBINARY
-    if flag(windowshack)
-      cpp-options: -DWINDOWS_LINKER_HACK
 
     if os(OSX)
         if flag(openblas)

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -37,6 +37,7 @@ typedef float  complex TCF;
 #define MEM      2002
 #define BAD_FILE 2003
 
+#define atanh ERROR(BAD_CODE);
 
 int sumF(KFVEC(x),FVEC(r)) {
     DEBUGMSG("sumF");

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -37,8 +37,6 @@ typedef float  complex TCF;
 #define MEM      2002
 #define BAD_FILE 2003
 
-#define atanh ERROR(BAD_CODE);
-
 int sumF(KFVEC(x),FVEC(r)) {
     DEBUGMSG("sumF");
     REQUIRES(rn==1,BAD_SIZE);
@@ -521,7 +519,8 @@ int mapR(int code, KDVEC(x), DVEC(r)) {
         OP(9,tanh)
         OP(10,asinh)
         OP(11,acosh)
-        OP(12,atanh)
+//        OP(12,atanh)
+        case 12: ERROR(BAD_CODE);
         OP(13,exp)
         OP(14,log)
         OP(15,sign)
@@ -547,7 +546,8 @@ int mapF(int code, KFVEC(x), FVEC(r)) {
         OP(9,tanh)
         OP(10,asinh)
         OP(11,acosh)
-        OP(12,atanh)
+//        OP(12,atanh)
+        case 12: ERROR(BAD_CODE);
         OP(13,exp)
         OP(14,log)
         OP(15,sign)

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -893,6 +893,12 @@ REQUIRES(an == bn && an == rn, BAD_SIZE);
 
 #define OPZOb(C,msg,O) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) r2p[k] = a2p[k] O b2p[k]; OK }
 #define OPZEb(C,msg,E) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) r2p[k] = E(a2p[k],b2p[k]); OK }
+
+int zipC(int code, KCVEC(a), KCVEC(b), CVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+/*
 int zipC(int code, KCVEC(a), KCVEC(b), CVEC(r)) {
     REQUIRES(an == bn && an == rn, BAD_SIZE);
     TCD* a2p = (TCD*)ap;
@@ -908,13 +914,18 @@ int zipC(int code, KCVEC(a), KCVEC(b), CVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-
+*/
 
 
 
 
 #define OPCZE(C,msg,E) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) rp[k] = complex_f_math_op(&E,ap[k],bp[k]); OK }
 
+int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+/*
 int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
     REQUIRES(an == bn && an == rn, BAD_SIZE);
     TCF* a2p = (TCF*)ap;
@@ -931,6 +942,7 @@ int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
+*/
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -503,6 +503,8 @@ inline float float_sign(float x) {
 #define OP(C,F) case C: { for(k=0;k<xn;k++) rp[k] = F(xp[k]); OK }
 #define OPV(C,E) case C: { for(k=0;k<xn;k++) rp[k] = E; OK }
 
+#ifdef WINDOWS_LINKER_HACK
+
 int mapR(int code, KDVEC(k), DVEC(r)) {
     ERROR(BAD_CODE);
 }
@@ -511,7 +513,8 @@ int mapF(int code, KDVEC(k), DVEC(r)) {
     ERROR(BAD_CODE);
 }
 
-/*
+#else
+
 int mapR(int code, KDVEC(x), DVEC(r)) {
     int k;
     REQUIRES(xn == rn,BAD_SIZE);
@@ -563,7 +566,8 @@ int mapF(int code, KFVEC(x), FVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
+
+#endif /* WINDOWS_LINKER_HACK */
 
 
 int mapI(int code, KIVEC(x), IVEC(r)) {
@@ -616,11 +620,14 @@ inline doublecomplex complex_signum_complex(doublecomplex z) {
 
 #define OPb(C,F) case C: { for(k=0;k<xn;k++) r2p[k] = F(x2p[k]); OK }
 
+#ifdef WINDOWS_LINKER_HACK
+
 int mapC(int cod, KCVEC(x), CVEC(r)) {
     ERROR(BAD_CODE);
 }
 
-/*
+#else 
+
 int mapC(int code, KCVEC(x), CVEC(r)) {
     TCD* x2p = (TCD*)xp;
     TCD* r2p = (TCD*)rp;
@@ -648,7 +655,8 @@ int mapC(int code, KCVEC(x), CVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
+
+#endif /* WINDOWS_LINKER_HACK */
 
 
 inline complex complex_f_math_fun(doublecomplex (*cf)(doublecomplex), complex a)
@@ -672,11 +680,14 @@ inline complex complex_f_math_fun(doublecomplex (*cf)(doublecomplex), complex a)
 
 #define OPC(C,F) case C: { for(k=0;k<xn;k++) rp[k] = complex_f_math_fun(&F,xp[k]); OK }
 
+#ifdef WINDOWS_LINKER_HACK
+
 int mapQ(int code, KQVEC(x), QVEC(r)) {
     ERROR(BAD_CODE);
 }
 
-/*
+#else 
+
 int mapQ(int code, KQVEC(x), QVEC(r)) {
     TCF* x2p = (TCF*)xp;
     TCF* r2p = (TCF*)rp;
@@ -704,7 +715,8 @@ int mapQ(int code, KQVEC(x), QVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
+
+#endif /* WINDOWS_LINKER_HACK */
 
 int mapValR(int code, double* pval, KDVEC(x), DVEC(r)) {
     int k;
@@ -781,11 +793,18 @@ inline doublecomplex complex_add(doublecomplex a, doublecomplex b) {
 
 #define OPVb(C,E) case C: { for(k=0;k<xn;k++) r2p[k] = E; OK }
 
+#ifdef WINDOWS_LINKER_HACK
+
 int mapValC(int code, doublecomplex* pval, KCVEC(x), CVEC(r)) {
     ERROR(BAD_CODE);
 }
 
-/*
+int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+#else 
+
 int mapValC(int code, doublecomplex* pval, KCVEC(x), CVEC(r)) {
     TCD* x2p = (TCD*)xp;
     TCD* r2p = (TCD*)rp;
@@ -803,13 +822,7 @@ int mapValC(int code, doublecomplex* pval, KCVEC(x), CVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
 
-int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
-    ERROR(BAD_CODE);
-}
-
-/*
 int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
     TCF* x2p = (TCF*)xp;
     TCF* r2p = (TCF*)rp;
@@ -827,8 +840,8 @@ int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
 
+#endif /* WINDOWS_LINKER_HACK */
 
 #define OPZE(C,msg,E) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) rp[k] = E(ap[k],bp[k]); OK }
 #define OPZV(C,msg,E) case C: {DEBUGMSG(msg) res = E(V(r),V(b)); CHECK(res,res); OK }
@@ -894,11 +907,18 @@ REQUIRES(an == bn && an == rn, BAD_SIZE);
 #define OPZOb(C,msg,O) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) r2p[k] = a2p[k] O b2p[k]; OK }
 #define OPZEb(C,msg,E) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) r2p[k] = E(a2p[k],b2p[k]); OK }
 
+#ifdef WINDOWS_LINKER_HACK
+
 int zipC(int code, KCVEC(a), KCVEC(b), CVEC(r)) {
     ERROR(BAD_CODE);
 }
 
-/*
+int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+#else 
+
 int zipC(int code, KCVEC(a), KCVEC(b), CVEC(r)) {
     REQUIRES(an == bn && an == rn, BAD_SIZE);
     TCD* a2p = (TCD*)ap;
@@ -914,18 +934,9 @@ int zipC(int code, KCVEC(a), KCVEC(b), CVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
-
-
-
 
 #define OPCZE(C,msg,E) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) rp[k] = complex_f_math_op(&E,ap[k],bp[k]); OK }
 
-int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
-    ERROR(BAD_CODE);
-}
-
-/*
 int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
     REQUIRES(an == bn && an == rn, BAD_SIZE);
     TCF* a2p = (TCF*)ap;
@@ -942,7 +953,8 @@ int zipQ(int code, KQVEC(a), KQVEC(b), QVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-*/
+
+#endif /* WINDOWS_LINKER_HACK */
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1285,7 +1297,14 @@ int sort_indexL(KLVEC(v),LVEC(r)) {
     SORTIDX_IMP(II,compare_longs_i)
 }
 
-static double round_hack (double x) {
+inline static double round_hack (double x) {
+
+#ifndef WINDOWS_LINKER_HACK
+
+  return round(x);
+
+#else 
+
   double fpart, ipart;
 
   fpart = modf(x, &ipart);
@@ -1295,6 +1314,8 @@ static double round_hack (double x) {
   } else {
     return ipart;
   }
+
+#endif /* WINDOWS_LINKER_HACK */
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -502,6 +502,16 @@ inline float float_sign(float x) {
 
 #define OP(C,F) case C: { for(k=0;k<xn;k++) rp[k] = F(xp[k]); OK }
 #define OPV(C,E) case C: { for(k=0;k<xn;k++) rp[k] = E; OK }
+
+int mapR(int code, KDVEC(k), DVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+int mapF(int code, KDVEC(k), DVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+/*
 int mapR(int code, KDVEC(x), DVEC(r)) {
     int k;
     REQUIRES(xn == rn,BAD_SIZE);
@@ -519,8 +529,7 @@ int mapR(int code, KDVEC(x), DVEC(r)) {
         OP(9,tanh)
         OP(10,asinh)
         OP(11,acosh)
-//        OP(12,atanh)
-        case 12: ERROR(BAD_CODE);
+        OP(12,atanh)
         OP(13,exp)
         OP(14,log)
         OP(15,sign)
@@ -546,7 +555,6 @@ int mapF(int code, KFVEC(x), FVEC(r)) {
         OP(9,tanh)
         OP(10,asinh)
         OP(11,acosh)
-//        OP(12,atanh)
         case 12: ERROR(BAD_CODE);
         OP(13,exp)
         OP(14,log)
@@ -555,6 +563,7 @@ int mapF(int code, KFVEC(x), FVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
+*/
 
 
 int mapI(int code, KIVEC(x), IVEC(r)) {

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -615,6 +615,12 @@ inline doublecomplex complex_signum_complex(doublecomplex z) {
 }
 
 #define OPb(C,F) case C: { for(k=0;k<xn;k++) r2p[k] = F(x2p[k]); OK }
+
+int mapC(int cod, KCVEC(x), CVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+/*
 int mapC(int code, KCVEC(x), CVEC(r)) {
     TCD* x2p = (TCD*)xp;
     TCD* r2p = (TCD*)rp;
@@ -642,7 +648,7 @@ int mapC(int code, KCVEC(x), CVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-
+*/
 
 
 inline complex complex_f_math_fun(doublecomplex (*cf)(doublecomplex), complex a)
@@ -665,6 +671,12 @@ inline complex complex_f_math_fun(doublecomplex (*cf)(doublecomplex), complex a)
 
 
 #define OPC(C,F) case C: { for(k=0;k<xn;k++) rp[k] = complex_f_math_fun(&F,xp[k]); OK }
+
+int mapQ(int code, KQVEC(x), QVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+/*
 int mapQ(int code, KQVEC(x), QVEC(r)) {
     TCF* x2p = (TCF*)xp;
     TCF* r2p = (TCF*)rp;
@@ -692,7 +704,7 @@ int mapQ(int code, KQVEC(x), QVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-
+*/
 
 int mapValR(int code, double* pval, KDVEC(x), DVEC(r)) {
     int k;

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -1285,13 +1285,24 @@ int sort_indexL(KLVEC(v),LVEC(r)) {
     SORTIDX_IMP(II,compare_longs_i)
 }
 
+static double round_hack (double x) {
+  double fpart, ipart;
+
+  fpart = modf(x, &ipart);
+
+  if (fpart > 0.5) {
+    return ipart + 1;
+  } else {
+    return ipart;
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 int round_vector(KDVEC(v),DVEC(r)) {
     int k;
     for(k=0; k<vn; k++) {
-        rp[k] = round(vp[k]);
+        rp[k] = round_hack(vp[k]);
     }
     OK
 }
@@ -1301,7 +1312,7 @@ int round_vector(KDVEC(v),DVEC(r)) {
 int round_vector_i(KDVEC(v),IVEC(r)) {
     int k;
     for(k=0; k<vn; k++) {
-        rp[k] = round(vp[k]);
+        rp[k] = round_hack(vp[k]);
     }
     OK
 }
@@ -1337,7 +1348,7 @@ int range_vector(IVEC(r)) {
 int round_vector_l(KDVEC(v),LVEC(r)) {
     int k;
     for(k=0; k<vn; k++) {
-        rp[k] = round(vp[k]);
+        rp[k] = round_hack(vp[k]);
     }
     OK
 }

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -780,6 +780,12 @@ inline doublecomplex complex_add(doublecomplex a, doublecomplex b) {
 }
 
 #define OPVb(C,E) case C: { for(k=0;k<xn;k++) r2p[k] = E; OK }
+
+int mapValC(int code, doublecomplex* pval, KCVEC(x), CVEC(r)) {
+    ERROR(BAD_CODE);
+}
+
+/*
 int mapValC(int code, doublecomplex* pval, KCVEC(x), CVEC(r)) {
     TCD* x2p = (TCD*)xp;
     TCD* r2p = (TCD*)rp;
@@ -797,8 +803,13 @@ int mapValC(int code, doublecomplex* pval, KCVEC(x), CVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
+*/
 
+int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
+    ERROR(BAD_CODE);
+}
 
+/*
 int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
     TCF* x2p = (TCF*)xp;
     TCF* r2p = (TCF*)rp;
@@ -816,7 +827,7 @@ int mapValQ(int code, complex* pval, KQVEC(x), QVEC(r)) {
         default: ERROR(BAD_CODE);
     }
 }
-
+*/
 
 
 #define OPZE(C,msg,E) case C: {DEBUGMSG(msg) for(k=0;k<an;k++) rp[k] = E(ap[k],bp[k]); OK }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,18 @@
 flags:
-#  hmatrix-special:
-#    safe-cheap: false
+  hmatrix-special:
+    safe-cheap: false
   hmatrix-tests:
-    gsl: false
+    gsl: true
   hmatrix:
-    openblas: true
-#  hmatrix-gsl:
-#    onlygsl: false
+    openblas: false
+  hmatrix-gsl:
+    onlygsl: false
 packages:
 - packages/tests/
-#- packages/special/
-#- packages/sparse/
-#- packages/gsl/
-#- packages/glpk/
+- packages/special/
+- packages/sparse/
+- packages/gsl/
+- packages/glpk/
 - packages/base/
 extra-deps: []
-resolver: lts-3.11
+resolver: lts-3.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,18 @@
 flags:
-  hmatrix-special:
-    safe-cheap: false
+#  hmatrix-special:
+#    safe-cheap: false
   hmatrix-tests:
     gsl: true
   hmatrix:
     openblas: false
-  hmatrix-gsl:
-    onlygsl: false
+#  hmatrix-gsl:
+#    onlygsl: false
 packages:
 - packages/tests/
-- packages/special/
-- packages/sparse/
-- packages/gsl/
-- packages/glpk/
+#- packages/special/
+#- packages/sparse/
+#- packages/gsl/
+#- packages/glpk/
 - packages/base/
 extra-deps: []
-resolver: lts-3.3
+resolver: lts-3.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ flags:
   hmatrix-tests:
     gsl: false
   hmatrix:
-    openblas: false
+    openblas: true
 #  hmatrix-gsl:
 #    onlygsl: false
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ flags:
 #  hmatrix-special:
 #    safe-cheap: false
   hmatrix-tests:
-    gsl: true
+    gsl: false
   hmatrix:
     openblas: false
 #  hmatrix-gsl:


### PR DESCRIPTION
I'm not sure if you want this in hmatrix proper, but 've experienced some weird linker errors like "unknown symbol atanh" when trying to compile my package that depends on hmatrix. I've added a workaround that conditionally disables some functions from vector-aux.c. The same tests pass with and without the workaround.
