### PR TITLE
Add Normed instance for Static matrix and vector

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -643,3 +643,18 @@ instance (KnownNat n', KnownNat m') => Testable (L n' m')
   where
     checkT _ = test
 
+--------------------------------------------------------------------------------
+
+instance KnownNat n => Normed (R n)
+  where
+    norm_0 v = norm_0 (extract v)
+    norm_1 v = norm_1 (extract v)
+    norm_2 v = norm_2 (extract v)
+    norm_Inf v = norm_Inf (extract v)
+
+instance (KnownNat m, KnownNat n) => Normed (L m n)
+  where
+    norm_0 m = norm_0 (extract m)
+    norm_1 m = norm_1 (extract m)
+    norm_2 m = norm_2 (extract m)
+    norm_Inf m = norm_Inf (extract m)


### PR DESCRIPTION
Follow-up to #164.

A few questions:

1. How do I properly export this instance? In the REPL, I was able to run commands like `norm_0 (fromList [1..5] :: R 5)`, so it seems to work. However, when I generated Haddock docs, these new instances did not appear under docs/Numeric-LinearAlgebra.html#t:Normed. 
2. Should I add tests?