### PR TITLE
Several additions to Static module

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -58,8 +58,8 @@ module Numeric.LinearAlgebra.Static(
     -- * Misc
     mean, meanCov,
     Disp(..), Domain(..),
-    withVector, exactLength, withMatrix, exactDims,
-    toRows, toColumns,
+    withVector, withMatrix, exactLength, exactDims,
+    toRows, toColumns, withRows, withColumns,
     Sized(..), Diag(..), Sym, sym, mTm, unSym, (<·>)
 ) where
 
@@ -381,9 +381,29 @@ splitCols = (tr *** tr) . splitRows . tr
 toRows :: forall m n . (KnownNat m, KnownNat n) => L m n -> [R n]
 toRows (LA.toRows . extract -> vs) = map mkR vs
 
+withRows
+    :: forall n z . KnownNat n
+    => [R n]
+    -> (forall m . KnownNat m => L m n -> z)
+    -> z
+withRows (LA.fromRows . map extract -> m) f =
+    case someNatVal $ fromIntegral $ LA.rows m of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) -> f (mkL m :: L m n)
 
 toColumns :: forall m n . (KnownNat m, KnownNat n) => L m n -> [R m]
 toColumns (LA.toColumns . extract -> vs) = map mkR vs
+
+withColumns
+    :: forall m z . KnownNat m
+    => [R m]
+    -> (forall n . KnownNat n => L m n -> z)
+    -> z
+withColumns (LA.fromColumns . map extract -> m) f =
+    case someNatVal $ fromIntegral $ LA.cols m of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy n)) -> f (mkL m :: L m n)
+
 
 
 --------------------------------------------------------------------------------

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -55,7 +55,7 @@ module Numeric.LinearAlgebra.Static(
     -- * Misc
     mean,
     Disp(..), Domain(..),
-    withVector, withMatrix,
+    withVector, exactLength, withMatrix, exactDims,
     toRows, toColumns,
     Sized(..), Diag(..), Sym, sym, mTm, unSym, (<·>)
 ) where
@@ -70,7 +70,7 @@ import Numeric.LinearAlgebra hiding (
     qr,size,dot,chol,range,R,C,sym,mTm,unSym)
 import qualified Numeric.LinearAlgebra as LA
 import qualified Numeric.LinearAlgebra.Devel as LA
-import Data.Proxy(Proxy)
+import Data.Proxy(Proxy(..))
 import Internal.Static
 import Control.Arrow((***))
 
@@ -395,6 +395,18 @@ withVector v f =
        Nothing -> error "static/dynamic mismatch"
        Just (SomeNat (_ :: Proxy m)) -> f (mkR v :: R m)
 
+-- | Useful for constraining two dependently typed vectors to match each
+-- other in length when they are unknown at compile-time.
+exactLength
+    :: forall n m. (KnownNat n, KnownNat m)
+    => R m
+    -> Maybe (R n)
+exactLength v
+    | natVal (Proxy :: Proxy n) == natVal (Proxy :: Proxy m)
+        = Just (mkR (unwrap v))
+    | otherwise
+        = Nothing
+
 withMatrix
     :: forall z
      . Matrix ℝ
@@ -408,6 +420,20 @@ withMatrix a f =
                Nothing -> error "static/dynamic mismatch"
                Just (SomeNat (_ :: Proxy n)) ->
                   f (mkL a :: L m n)
+
+-- | Useful for constraining two dependently typed matrices to match each
+-- other in dimensions when they are unknown at compile-time.
+exactDims
+    :: forall n m j k. (KnownNat n, KnownNat m, KnownNat j, KnownNat k)
+    => L m n
+    -> Maybe (L j k)
+exactDims m
+    | natVal (Proxy :: Proxy m) == natVal (Proxy :: Proxy j)
+   && natVal (Proxy :: Proxy n) == natVal (Proxy :: Proxy k)
+        = Just (mkL (unwrap m))
+    | otherwise
+        = Nothing
+
 
 --------------------------------------------------------------------------------
 

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -56,7 +56,7 @@ module Numeric.LinearAlgebra.Static(
     Seed, RandDist(..),
     randomVector, rand, randn, gaussianSample, uniformSample,
     -- * Misc
-    mean,
+    mean, meanCov,
     Disp(..), Domain(..),
     withVector, exactLength, withMatrix, exactDims,
     toRows, toColumns,
@@ -71,7 +71,7 @@ import Numeric.LinearAlgebra hiding (
     (<\>),fromList,takeDiag,svd,eig,eigSH,
     eigenvalues,eigenvaluesSH,build,
     qr,size,dot,chol,range,R,C,sym,mTm,unSym,
-    randomVector,rand,randn,gaussianSample,uniformSample)
+    randomVector,rand,randn,gaussianSample,uniformSample,meanCov)
 import qualified Numeric.LinearAlgebra as LA
 import qualified Numeric.LinearAlgebra.Devel as LA
 import Data.Proxy(Proxy(..))
@@ -479,6 +479,11 @@ uniformSample s (extract -> mins) (extract -> maxs) =
     mkL $ LA.uniformSample s (fromInteger (natVal (Proxy :: Proxy m)))
                            (zip (LA.toList mins) (LA.toList maxs))
 
+meanCov
+    :: forall m n . (KnownNat m, KnownNat n)
+    => L m n
+    -> (R n, Sym n)
+meanCov (extract -> vs) = mkR *** (Sym . mkL . LA.unSym) $ LA.meanCov vs
 
 --------------------------------------------------------------------------------
 

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -49,7 +49,7 @@ module Numeric.LinearAlgebra.Static(
     linSolve, (<\>),
     -- * Factorizations
     svd, withCompactSVD, svdTall, svdFlat, Eigen(..),
-    withNullspace, qr, chol,
+    withNullspace, withOrth, qr, chol,
     -- * Norms
     Normed(..),
     -- * Random arrays
@@ -326,6 +326,15 @@ withNullspace (LA.nullspace . extract -> a) f =
        Nothing -> error "static/dynamic mismatch"
        Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
 
+withOrth
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k. (KnownNat k) => L n k -> z)
+    -> z
+withOrth (LA.orth . extract -> a) f =
+    case someNatVal $ fromIntegral $ cols a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
 
 withCompactSVD
     :: forall m n z . (KnownNat m, KnownNat n)

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -71,7 +71,7 @@ import Numeric.LinearAlgebra hiding (
     (<\>),fromList,takeDiag,svd,eig,eigSH,
     eigenvalues,eigenvaluesSH,build,
     qr,size,dot,chol,range,R,C,sym,mTm,unSym,
-    randomVector, rand, randn, gaussianSample, uniformSample)
+    randomVector,rand,randn,gaussianSample,uniformSample)
 import qualified Numeric.LinearAlgebra as LA
 import qualified Numeric.LinearAlgebra.Devel as LA
 import Data.Proxy(Proxy(..))

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -595,13 +595,14 @@ outerR :: (KnownNat m, KnownNat n) => R n -> R m -> L n m
 outerR (extract -> x) (extract -> y) = mkL (LA.outer x y)
 
 mapR :: KnownNat n => (ℝ -> ℝ) -> R n -> R n
-mapR f (extract -> v) = mkR (LA.cmap f v)
+mapR f (unwrap -> v) = mkR (LA.cmap f v)
 
 zipWithR :: KnownNat n => (ℝ -> ℝ -> ℝ) -> R n -> R n -> R n
 zipWithR f (extract -> x) (extract -> y) = mkR (LA.zipVectorWith f x y)
 
-mapM' :: (KnownNat n, KnownNat m) => (ℂ -> ℂ) -> M n m -> M n m
-mapM' f (extract -> m) = mkM (LA.cmap f m)
+mapL :: (KnownNat n, KnownNat m) => (ℝ -> ℝ) -> L n m -> L n m
+mapL f (unwrap -> m) = mkL (LA.cmap f m)
+
 
 --------------------------------------------------------------------------------
 
@@ -645,13 +646,14 @@ outerC :: (KnownNat m, KnownNat n) => C n -> C m -> M n m
 outerC (extract -> x) (extract -> y) = mkM (LA.outer x y)
 
 mapC :: KnownNat n => (ℂ -> ℂ) -> C n -> C n
-mapC f (extract -> v) = mkC (LA.cmap f v)
+mapC f (unwrap -> v) = mkC (LA.cmap f v)
 
 zipWithC :: KnownNat n => (ℂ -> ℂ -> ℂ) -> C n -> C n -> C n
 zipWithC f (extract -> x) (extract -> y) = mkC (LA.zipVectorWith f x y)
 
-mapL :: (KnownNat n, KnownNat m) => (ℝ -> ℝ) -> L n m -> L n m
-mapL f (extract -> m) = mkL (LA.cmap f m)
+mapM' :: (KnownNat n, KnownNat m) => (ℂ -> ℂ) -> M n m -> M n m
+mapM' f (unwrap -> m) = mkM (LA.cmap f m)
+
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
(Follow-up after comments in https://github.com/albertoruiz/hmatrix/pull/163#issuecomment-168936110 )

Not sure if the proper procedure is to create a bunch of small branches with individual PR's...but here is just a bunch of "ports" of non-static functions being brought into the Static module

1. `zipWith` added to the `Domain` typeclass.  (should this name be different?  `dzipWith`?)

2. Added `exactLength` and `exactDims`, to as utility functions for constraining multiple dependently typed vectors/matrices whose sizes aren't known at compile-time to have the same size.  A sample usage might be:

        withVector v1 $ \(r1 :: R n) ->
        withVector v2 $ \(r2 :: R m) ->
          case exactLength r2 of
            Nothing  -> -- cannot zip the two; they are of different lengths
            Just r2' -> zipWith (+) r1 r2'   -- now assured to have the same
                                             -- length, so can be zipped together

    This is a simple contrived example (You could do something to the same effect by just using `create`, instead of `withVector`, on `v2`), but in more complex cases, this becomes more useful.

    Name choice comes from the equivalent function in Idris.

3. Ported the random generator functions, which use return-type polymorphism to do cute tricks like not requiring the desired dimension of vector/matrix to be explicitly given.  The desired length can be inferred through type inference in later usage, or given explicitly at the call side with a type annotation.

    There are a couple of issues with the importing process.  For one, `gaussianSample` and `uniformSample` return `L m n`, but the `m` isn't really of any significance in a linear algebra sense, and I can think of only nice cases where having the `m` would be useful at compile time.  It doesn't add to much in terms of type safety except for some contrived use cases.  Instead, they could be made to return `[R n]`, instead, and have the number of items desired be explicitly given.

    However, there *are* some contrived cases I can think of in my head where it might be useful to have the full statically-known `L m n`, so it might just be worth leaving in for those cases?

4. Added `meanCov`; pretty straightforward.  One note is that the API essentially takes in `[R n]`, it's asked for as an `L m n`.  The `m` type parameter is effectively ignored and unused, and doesn't add anything in terms of type safety.  I'm not sure if it would be "best" to simply have it take in an `[R n]` instead, but the actual `meanCov` in `Data.LinearAlgebra` is implemented with a matrix as an input, so it might be okay to leave it that way.

   One issue that taking `L m n` instead of `[R n]`, though, is that perhaps a user might *have* an `[R n]`, ~~and it would be somewhat annoying to convert an `[R n]` into a `L m n` *just* for the sake of being able to use `meanCov`~~.  **edit**: I've added the `withRows` function to make this a bit easier to do, so it's probably not as annoying anymore.

    If anything, having the `m` in the type signature might be confusing, or at worst, dishonest.

5. `withOrth` added, which is a straightforward parallel to `withNullSpace`.

6. `withRows` and `withColumns`, as inverses of `toRows` and `toColumns` and to be able to use "lists of rows" in a case where the function is asking for `L m n` -- for example, with the current implementation of `meanCov`.

Some notes/comments:

* Given the purpose of `Sized` (converting to and from sized and unsized variants), it would make sense for me to have an instance of `Sized` for `Her` and `Sym`, with `Herm` as the underlying unsized type.  This would be useful for people who want to convert their `Herm`s in and out of `Static` with statically-typed assurances.  This sort of makes sense if you do hacky cludges for `fromList`...but the problem is `IndexOf`, when defining `size`.  There is no type family instance for `IndexOf Herm`.  Is it okay for me to just add it in?  Does it make sense/is consistent with the rest of the library to have

        type instance IndexOf Herm = (Int, Int)

    ?

* I feel like there might be value in adding GADT-based existential constructors, to take the place of `(forall n. KnownNat n => R n -> z) -> z`.  In particular:

        data SomeVec :: * where
            SomeVec :: KnownNat n => R n -> SomeVec
        data SomeMat :: * where
            SomeMat :: (KnownNat n, KnownNat m) => L m n -> SomeMat

    and potentially

        data SomeRows :: Nat -> * where
            SomeRows :: KnownNat m => L m n -> SomeRows n

        data SomeCols :: Nat -> * where
            SomeCols :: KnownNat n => L m n -> SomeRows m

    The reason why I think these have usefulness beyond using `(forall n. KnownNat n => R n -> z) -> z` everywhere is that `SomeVec`, `SomeMat`, `SomeRows`, etc., can be **serialized** and have `Storable` instances (or `Binary` or `Serialize` instances, etc.).  One can serialize and store `SomeVec`'s, and then deserialize them/read them from memory, *equipped* with type-level proofs of their sizes.  This is a bit smoother of a process than going through serializing the extracted vector and then deserializing and then using `withVector`, etc.; Haskell just overall seems to work smoother with data and constructors, and less so with continuations.

    But, this is 100% stylistic, I think, and the benefits might not be enough to warrant the extra clutter.  If anything, these types could be provided as an extra library, and we wouldn't even have to worry about orphan instances because the instances would be on the wrapper types.  Just throwing this out there :)