### PR TITLE
changed zipWith to zipWithVector to match Numeric.LinearAlgebra.Devel and avoid conflicts

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -526,7 +526,7 @@ class Domain field vec mat | mat -> vec field, vec -> mat field, field -> mat ve
     dvmap :: forall n. KnownNat n => (field -> field) -> vec n -> vec n
     dmmap :: forall n m. (KnownNat m, KnownNat n) => (field -> field) -> mat n m -> mat n m
     outer :: forall n m. (KnownNat m, KnownNat n) => vec n -> vec m -> mat n m
-    zipWith :: forall n. KnownNat n => (field -> field -> field) -> vec n -> vec n -> vec n
+    zipWithVector :: forall n. KnownNat n => (field -> field -> field) -> vec n -> vec n -> vec n
 
 
 instance Domain ℝ R L
@@ -539,7 +539,7 @@ instance Domain ℝ R L
     dvmap = mapR
     dmmap = mapL
     outer = outerR
-    zipWith = zipWithR
+    zipWithVector = zipWithR
 
 instance Domain ℂ C M
   where
@@ -551,7 +551,7 @@ instance Domain ℂ C M
     dvmap = mapC
     dmmap = mapM'
     outer = outerC
-    zipWith = zipWithC
+    zipWithVector = zipWithC
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Sorry, just a minor fix; the fact that most of the functions in this package can be used by importing unqualified is broken by the `zipWith` name I introduced in my last PR; if you wanted, here's a patch with the name changed to `zipWithVector`, in order to be more consistent with naming conventions in the package (the same function is provided as `zipWithVector` in `Numeric.LinearAlgebra.Devel`).  Feel free to close if you think `zipWith` works better! :)