### PR TITLE
Add Num, Fractional, Floating instances for Sym

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -802,10 +802,11 @@ instance KnownNat n =>  Num (Sym n)
 
 instance KnownNat n => Fractional (Sym n)
   where
-    fromRational = Sym . L . Dim . Dim . fromRational
+    fromRational = Sym . fromRational
     (/) = mkSym2 (/)
 
-instance KnownNat n => Floating (Sym n) where
+instance KnownNat n => Floating (Sym n)
+  where
     sin   = mkSym sin
     cos   = mkSym cos
     tan   = mkSym tan

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -786,3 +786,40 @@ instance (KnownNat m, KnownNat n) => Normed (L m n)
     norm_1 m = norm_1 (extract m)
     norm_2 m = norm_2 (extract m)
     norm_Inf m = norm_Inf (extract m)
+
+mkSym f = Sym . f . unSym
+mkSym2 f x y = Sym (f (unSym x) (unSym y))
+
+instance KnownNat n =>  Num (Sym n)
+  where
+    (+) = mkSym2 (+)
+    (*) = mkSym2 (*)
+    (-) = mkSym2 (-)
+    abs = mkSym abs
+    signum = mkSym signum
+    negate = mkSym negate
+    fromInteger = Sym . fromInteger
+
+instance KnownNat n => Fractional (Sym n)
+  where
+    fromRational = Sym . L . Dim . Dim . fromRational
+    (/) = mkSym2 (/)
+
+instance KnownNat n => Floating (Sym n) where
+    sin   = mkSym sin
+    cos   = mkSym cos
+    tan   = mkSym tan
+    asin  = mkSym asin
+    acos  = mkSym acos
+    atan  = mkSym atan
+    sinh  = mkSym sinh
+    cosh  = mkSym cosh
+    tanh  = mkSym tanh
+    asinh = mkSym asinh
+    acosh = mkSym acosh
+    atanh = mkSym atanh
+    exp   = mkSym exp
+    log   = mkSym log
+    sqrt  = mkSym sqrt
+    (**)  = mkSym2 (**)
+    pi    = Sym pi


### PR DESCRIPTION
I did this without thinking very hard, so it may be the case that some of these operations don't actually produce symmetric matrices. In that case, we should probably get rid of those instances.