### PR TITLE
Update numeric class top level documentation.

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra.hs
+++ b/packages/base/src/Numeric/LinearAlgebra.hs
@@ -22,7 +22,8 @@ module Numeric.LinearAlgebra (
 
     -- * Numeric classes
     -- |
-    -- The standard numeric classes are defined elementwise:
+    -- The standard numeric classes are defined elementwise (commonly referred to
+    -- as the Hadamard product or the Schur product):
     --
     -- >>>  vector [1,2,3] * vector [3,0,-2]
     -- fromList [3.0,0.0,-6.0]


### PR DESCRIPTION
Noted that the numeric classes for Matrix and Vector which are defined elementwise are commonly referred to as the Hadamard (or Schur) product.