### PR TITLE
[In Progress] Ongoing porting of functionality to Static module

### DIFF
--- a/packages/base/src/Internal/Static.hs
+++ b/packages/base/src/Internal/Static.hs
@@ -518,6 +518,18 @@ instance (KnownNat n, KnownNat m) => Floating (M n m) where
     (**)  = lift2MD (**)
     pi    = M pi
 
+instance Additive (R n) where
+    add = (+)
+
+instance Additive (C n) where
+    add = (+)
+
+instance (KnownNat m, KnownNat n) => Additive (L m n) where
+    add = (+)
+
+instance (KnownNat m, KnownNat n) => Additive (M m n) where
+    add = (+)
+
 --------------------------------------------------------------------------------
 
 

--- a/packages/base/src/Internal/Static.hs
+++ b/packages/base/src/Internal/Static.hs
@@ -567,6 +567,17 @@ instance KnownNat n => Disp (C n)
 
 --------------------------------------------------------------------------------
 
+overMatL' :: (KnownNat m, KnownNat n)
+          => (LA.Matrix ℝ -> LA.Matrix ℝ) -> L m n -> L m n
+overMatL' f = mkL . f . unwrap
+{-# INLINE overMatL' #-}
+
+overMatM' :: (KnownNat m, KnownNat n)
+          => (LA.Matrix ℂ -> LA.Matrix ℂ) -> M m n -> M m n
+overMatM' f = mkM . f . unwrap
+{-# INLINE overMatM' #-}
+
+
 #else
 
 module Numeric.LinearAlgebra.Static.Internal where

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -821,3 +821,10 @@ instance KnownNat n => Floating (Sym n)
     sqrt  = mkSym sqrt
     (**)  = mkSym2 (**)
     pi    = Sym pi
+
+instance KnownNat n => Additive (Sym n) where
+    add = (+)
+
+instance KnownNat n => Transposable (Sym n) (Sym n) where
+    tr (Sym m) = Sym (tr m)
+    tr' = id

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -827,4 +827,8 @@ instance KnownNat n => Additive (Sym n) where
 
 instance KnownNat n => Transposable (Sym n) (Sym n) where
     tr (Sym m) = Sym (tr m)
-    tr' = id
+    tr'        = id
+
+instance KnownNat n => Transposable (Her n) (Her n) where
+    tr          = id
+    tr' (Her m) = Her (tr' m)

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -537,6 +537,8 @@ class Domain field vec mat | mat -> vec field, vec -> mat field, field -> mat ve
     zipWithVector :: forall n. KnownNat n => (field -> field -> field) -> vec n -> vec n -> vec n
     det :: forall n. KnownNat n => mat n n -> field
     invlndet :: forall n. KnownNat n => mat n n -> (mat n n, (field, field))
+    expm :: forall n. KnownNat n => mat n n -> mat n n
+    sqrtm :: forall n. KnownNat n => mat n n -> mat n n
 
 
 instance Domain ℝ R L
@@ -552,6 +554,8 @@ instance Domain ℝ R L
     zipWithVector = zipWithR
     det = detL
     invlndet = invlndetL
+    expm = expmL
+    sqrtm = sqrtmL
 
 instance Domain ℂ C M
   where
@@ -566,6 +570,8 @@ instance Domain ℂ C M
     zipWithVector = zipWithC
     det = detM
     invlndet = invlndetM
+    expm = expmM
+    sqrtm = sqrtmM
 
 --------------------------------------------------------------------------------
 
@@ -615,13 +621,19 @@ zipWithR :: KnownNat n => (ℝ -> ℝ -> ℝ) -> R n -> R n -> R n
 zipWithR f (extract -> x) (extract -> y) = mkR (LA.zipVectorWith f x y)
 
 mapL :: (KnownNat n, KnownNat m) => (ℝ -> ℝ) -> L n m -> L n m
-mapL f (unwrap -> m) = mkL (LA.cmap f m)
+mapL f = overMatL' (LA.cmap f)
 
 detL :: KnownNat n => Sq n -> ℝ
 detL = LA.det . unwrap
 
 invlndetL :: KnownNat n => Sq n -> (L n n, (ℝ, ℝ))
 invlndetL = first mkL . LA.invlndet . unwrap
+
+expmL :: KnownNat n => Sq n -> Sq n
+expmL = overMatL' LA.expm
+
+sqrtmL :: KnownNat n => Sq n -> Sq n
+sqrtmL = overMatL' LA.sqrtm
 
 --------------------------------------------------------------------------------
 
@@ -671,13 +683,19 @@ zipWithC :: KnownNat n => (ℂ -> ℂ -> ℂ) -> C n -> C n -> C n
 zipWithC f (extract -> x) (extract -> y) = mkC (LA.zipVectorWith f x y)
 
 mapM' :: (KnownNat n, KnownNat m) => (ℂ -> ℂ) -> M n m -> M n m
-mapM' f (unwrap -> m) = mkM (LA.cmap f m)
+mapM' f = overMatM' (LA.cmap f)
 
 detM :: KnownNat n => M n n -> ℂ
 detM = LA.det . unwrap
 
 invlndetM :: KnownNat n => M n n -> (M n n, (ℂ, ℂ))
 invlndetM = first mkM . LA.invlndet . unwrap
+
+expmM :: KnownNat n => M n n -> M n n
+expmM = overMatM' LA.expm
+
+sqrtmM :: KnownNat n => M n n -> M n n
+sqrtmM = overMatM' LA.sqrtm
 
 
 --------------------------------------------------------------------------------

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -79,6 +79,7 @@ import Internal.Static
 import Control.Arrow((***))
 import Text.Printf
 import Data.Type.Equality ((:~:)(Refl))
+import Data.Bifunctor (first)
 
 ud1 :: R n -> Vector ℝ
 ud1 (R (Dim v)) = v
@@ -534,6 +535,8 @@ class Domain field vec mat | mat -> vec field, vec -> mat field, field -> mat ve
     dmmap :: forall n m. (KnownNat m, KnownNat n) => (field -> field) -> mat n m -> mat n m
     outer :: forall n m. (KnownNat m, KnownNat n) => vec n -> vec m -> mat n m
     zipWithVector :: forall n. KnownNat n => (field -> field -> field) -> vec n -> vec n -> vec n
+    det :: forall n. KnownNat n => mat n n -> field
+    invlndet :: forall n. KnownNat n => mat n n -> (mat n n, (field, field))
 
 
 instance Domain ℝ R L
@@ -547,6 +550,8 @@ instance Domain ℝ R L
     dmmap = mapL
     outer = outerR
     zipWithVector = zipWithR
+    det = detL
+    invlndet = invlndetL
 
 instance Domain ℂ C M
   where
@@ -559,6 +564,8 @@ instance Domain ℂ C M
     dmmap = mapM'
     outer = outerC
     zipWithVector = zipWithC
+    det = detM
+    invlndet = invlndetM
 
 --------------------------------------------------------------------------------
 
@@ -610,6 +617,11 @@ zipWithR f (extract -> x) (extract -> y) = mkR (LA.zipVectorWith f x y)
 mapL :: (KnownNat n, KnownNat m) => (ℝ -> ℝ) -> L n m -> L n m
 mapL f (unwrap -> m) = mkL (LA.cmap f m)
 
+detL :: KnownNat n => Sq n -> ℝ
+detL = LA.det . unwrap
+
+invlndetL :: KnownNat n => Sq n -> (L n n, (ℝ, ℝ))
+invlndetL = first mkL . LA.invlndet . unwrap
 
 --------------------------------------------------------------------------------
 
@@ -660,6 +672,12 @@ zipWithC f (extract -> x) (extract -> y) = mkC (LA.zipVectorWith f x y)
 
 mapM' :: (KnownNat n, KnownNat m) => (ℂ -> ℂ) -> M n m -> M n m
 mapM' f (unwrap -> m) = mkM (LA.cmap f m)
+
+detM :: KnownNat n => M n n -> ℂ
+detM = LA.det . unwrap
+
+invlndetM :: KnownNat n => M n n -> (M n n, (ℂ, ℂ))
+invlndetM = first mkM . LA.invlndet . unwrap
 
 
 --------------------------------------------------------------------------------

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -42,7 +42,7 @@ module Numeric.LinearAlgebra.Static(
     blockAt,
     matrix,
     -- * Complex
-    C, M, Her, her, 𝑖,
+    ℂ, C, M, Her, her, 𝑖,
     -- * Products
     (<>),(#>),(<.>),
     -- * Linear Systems

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -78,6 +78,7 @@ import Data.Proxy(Proxy(..))
 import Internal.Static
 import Control.Arrow((***))
 import Text.Printf
+import Data.Type.Equality ((:~:)(Refl))
 
 ud1 :: R n -> Vector ℝ
 ud1 (R (Dim v)) = v
@@ -444,11 +445,9 @@ exactLength
     :: forall n m . (KnownNat n, KnownNat m)
     => R m
     -> Maybe (R n)
-exactLength v
-    | natVal (Proxy :: Proxy n) == natVal (Proxy :: Proxy m)
-        = Just (mkR (unwrap v))
-    | otherwise
-        = Nothing
+exactLength v = do
+    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy m)
+    return $ mkR (unwrap v)
 
 withMatrix
     :: forall z
@@ -470,12 +469,10 @@ exactDims
     :: forall n m j k . (KnownNat n, KnownNat m, KnownNat j, KnownNat k)
     => L m n
     -> Maybe (L j k)
-exactDims m
-    | natVal (Proxy :: Proxy m) == natVal (Proxy :: Proxy j)
-   && natVal (Proxy :: Proxy n) == natVal (Proxy :: Proxy k)
-        = Just (mkL (unwrap m))
-    | otherwise
-        = Nothing
+exactDims m = do
+    Refl <- sameNat (Proxy :: Proxy m) (Proxy :: Proxy j)
+    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy k)
+    return $ mkL (unwrap m)
 
 randomVector
     :: forall n . KnownNat n

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -844,8 +844,8 @@ instance KnownNat n => Additive (Sym n) where
     add = (+)
 
 instance KnownNat n => Transposable (Sym n) (Sym n) where
-    tr (Sym m) = Sym (tr m)
-    tr'        = id
+    tr  = id
+    tr' = id
 
 instance KnownNat n => Transposable (Her n) (Her n) where
     tr          = id


### PR DESCRIPTION
Just continuing on #163, #167, #168, #172 and assorted PR's to add more functionality to the Static module, if you wanted it.  I'm putting this here as a PR so you can let me know if there's functionality or additions that you disagree with, so I can get rid of/modify them immediately!  I'm maintaining an online up-to-date haddocks of my changes at http://mstksg.github.io/hmatrix/ .

The main guiding principle behind these additions is https://github.com/albertoruiz/hmatrix/pull/163#issuecomment-168936110 , which sets out the following criteria:

* If the the relationship between the function's input size and output size is important and can be taken advantage of by the type system (ie, `zipWithVec`, `cvmap`, `tr`)
* If the untyped function is *partial*, but adding static type parameters makes it total (ie, `expm`, `eigenvalues`, `det`)

This excludes functions where knowing the output or input dimensions yields nothing of significance, like `sumElements`.

These guidelines give the advantages that:

*  The user of the library/API will not have to worry about partial functions, or informally proving functions to be total in their head (ie, `LA.det . unwrap`, which is technically total, but not verifiable by the compiler) --- the compiler will do the proofs *for* them, and verify the code.

* For functions with interesting relationships between the input and return types (ie, `<>`), parametric polymorphism helps the user write code by guiding them with typed holes and hints, restricting implementations.

* Input and output dimensions are now readable straight from the types and enforced by the type system, instead of only through documentation, eliminating confusion. (ie, `uniformSample`)

## Notes

A lot of functionality is being thrown into the `Domain` typeclass, but only because it allows us to export both `R`/`C` and `L`/`M` varieties.  This creates a bloated typeclass, which might not be very ideal.

This can be fixed if `R`/`C` and `L`/`M` are merged to be *parameterized* type constructors, and things like `expm`, `det`, etc. can simply be defined for `Field t => ...`, like they are in the normal, untyped libraries.  This simplifies the interface by lightening the typeclass...and I actually don't think it would be a breaking change for the API (as long as `R`, `C`, `L`, `M` are turned to appropriate type synonyms).

It'll also let us generalize functions right now that are unnecessarily specialized, like `withMatrix`, `withVector`, `withRows`, etc.  There'd also be some larger returns down the line, too, if we decide to add the numerous factorization schemes.