### PR TITLE
Hotfixes for 0.17.0.1 to build with GHC 8, for upcoming stackage nightlies

### DIFF
--- a/packages/base/src/Internal/Matrix.hs
+++ b/packages/base/src/Internal/Matrix.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeOperators            #-}
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE ViewPatterns             #-}
+{-# LANGUAGE ConstrainedClassMethods  #-}
 
 
 

--- a/packages/base/src/Internal/Modular.hs
+++ b/packages/base/src/Internal/Modular.hs
@@ -72,7 +72,7 @@ instance (Ord t, KnownNat m) => Ord (Mod m t)
   where
     compare a b = compare (unMod a) (unMod b)
 
-instance (Real t, KnownNat m, Integral (Mod m t)) => Real (Mod m t)
+instance (Integral t, KnownNat m, Integral (Mod m t)) => Real (Mod m t)
   where
     toRational x = toInteger x % 1
 


### PR DESCRIPTION
In response to #192 , so we can have the current **stable** hmatrix on the stackage nightlies for now :)

Meant as simply a hotfix for 0.17.0.1, because HEAD (0.18.0.0) already builds fine with 8.0