### PR TITLE
Redefine (#), fixes #198

### DIFF
--- a/packages/base/src/Internal/Devel.hs
+++ b/packages/base/src/Internal/Devel.hs
@@ -80,8 +80,8 @@ class TransArray c
   where
     type Trans c b
     type TransRaw c b
-    apply      :: (Trans c b) -> c -> b
-    applyRaw   :: (TransRaw c b) -> c -> b
+    apply      :: c -> (b -> IO r) -> (Trans c b) -> IO r
+    applyRaw   :: c -> (b -> IO r) -> (TransRaw c b) -> IO r
     infixl 1 `apply`, `applyRaw`
 
 instance Storable t => TransArray (Vector t)
@@ -92,4 +92,3 @@ instance Storable t => TransArray (Vector t)
     {-# INLINE apply #-}
     applyRaw = avec
     {-# INLINE applyRaw #-}
-

--- a/packages/base/src/Internal/Sparse.hs
+++ b/packages/base/src/Internal/Sparse.hs
@@ -144,13 +144,13 @@ gmXv :: GMatrix -> Vector Double -> Vector Double
 gmXv SparseR { gmCSR = CSR{..}, .. } v = unsafePerformIO $ do
     dim v /= nCols ~!~ printf "gmXv (CSR): incorrect sizes: (%d,%d) x %d" nRows nCols (dim v)
     r <- createVector nRows
-    c_smXv # csrVals # csrCols # csrRows # v # r #|"CSRXv"
+    (csrVals # csrCols # csrRows # v #! r) c_smXv #|"CSRXv"
     return r
 
 gmXv SparseC { gmCSC = CSC{..}, .. } v = unsafePerformIO $ do
     dim v /= nCols ~!~ printf "gmXv (CSC): incorrect sizes: (%d,%d) x %d" nRows nCols (dim v)
     r <- createVector nRows
-    c_smTXv # cscVals # cscRows # cscCols # v # r #|"CSCXv"
+    (cscVals # cscRows # cscCols # v #! r) c_smTXv #|"CSCXv"
     return r
 
 gmXv Diag{..} v
@@ -211,4 +211,3 @@ instance Transposable GMatrix GMatrix
     tr (Diag v n m) = Diag v m n
     tr (Dense a n m) = Dense (tr a) m n
     tr' = tr
-


### PR DESCRIPTION
This PR fixes a subtle bug in the definition of `(#)`. To recap the previous definition of `(#)` specialised to `Vector`s was:

```haskell
avec :: Storable a => (CInt -> Ptr a -> b) -> Vector a -> b
avec f v = inlinePerformIO (unsafeWith v (return . f (fromIntegral (Vector.length v))))
```

`b` will be unified with further function types, and eventually IO. However note the part `unsafeWith v (return (..))`: We are not actually executing the eventual nested IO action, but rather just returning it! This means that the IO that `b` will be unified with escapes the bracket of `unsafeWith`.

This resulted in rare cases of segfaults/corrupt memory, as the runtime deallocated the underlying memory earlier than FFI calls finished.

This fix redefines `(#)` to build up a continuation `((CInt -> Ptr a -> ... -> IO r) -> IO r)` instead that nests the passed in function into the `unsafeWith` brackets safely. This also avoids the use of `inlinePerformIO`.