### PR TITLE
implement thinQR and thinRQ

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra.hs
+++ b/packages/base/src/Numeric/LinearAlgebra.hs
@@ -126,7 +126,7 @@ module Numeric.LinearAlgebra (
     geigSH,
 
     -- * QR
-    qr, rq, qrRaw, qrgr,
+    qr, thinQR, rq, thinRQ, qrRaw, qrgr,
 
     -- * Cholesky
     chol, mbChol,


### PR DESCRIPTION
`qr` and `rq` are very slow for large matrices because `unpackQR` is very slow [#201]. This patch implements `thinQR` and `thinRQ` using `qrgr`, which is much faster.