### PR TITLE
document norm functions and fix compactSVDTol documentation

### DIFF
--- a/packages/base/src/Internal/Algorithms.hs
+++ b/packages/base/src/Internal/Algorithms.hs
@@ -294,7 +294,7 @@ fromList [35.18264833189422,1.4769076999800903]
 compactSVD :: Field t  => Matrix t -> (Matrix t, Vector Double, Matrix t)
 compactSVD = compactSVDTol 1
 
--- | @compactSVDTol r@ is similar to 'compactSVDTol', but uses tolerance @tol=r*g*eps*(max rows cols)@ to distinguish nonzero singular values, where @g@ is the greatest singular value.
+-- | @compactSVDTol r@ is similar to 'compactSVD', but uses tolerance @tol=r*g*eps*(max rows cols)@ to distinguish nonzero singular values, where @g@ is the greatest singular value.
 compactSVDTol :: Field t  => Double -> Matrix t -> (Matrix t, Vector Double, Matrix t)
 compactSVDTol r m = (u', subVector 0 d s, v') where
     (u,s,v) = thinSVD m

--- a/packages/base/src/Internal/Util.hs
+++ b/packages/base/src/Internal/Util.hs
@@ -255,6 +255,7 @@ norm :: Vector Double -> Double
 -- ^ 2-norm of real vector
 norm = pnorm PNorm2
 
+-- | p-norm for vectors, operator norm for matrices
 class Normed a
   where
     norm_0   :: a -> R
@@ -319,10 +320,11 @@ instance Normed (Vector (Complex Float))
     norm_2 = norm_2 . double
     norm_Inf = norm_Inf . double
 
-
+-- | Frobenius norm (Schatten p-norm with p=2)
 norm_Frob :: (Normed (Vector t), Element t) => Matrix t -> R
 norm_Frob = norm_2 . flatten
 
+-- | Sum of singular values (Schatten p-norm with p=1)
 norm_nuclear :: Field t => Matrix t -> R
 norm_nuclear = sumElements . singularValues
 


### PR DESCRIPTION
sid-kap pointed out a mistake in the compactSVDTol documentation. I also added some documentation for the norm functions.