### PR TITLE
compactSVDTol doc and inline dim and subVector

### DIFF
--- a/packages/base/src/Internal/Algorithms.hs
+++ b/packages/base/src/Internal/Algorithms.hs
@@ -294,7 +294,7 @@ fromList [35.18264833189422,1.4769076999800903]
 compactSVD :: Field t  => Matrix t -> (Matrix t, Vector Double, Matrix t)
 compactSVD = compactSVDTol 1
 
--- | @compactSVDTol r@ is similar to 'compactSVD', but uses tolerance @tol=r*g*eps*(max rows cols)@ to distinguish nonzero singular values, where @g@ is the greatest singular value.
+-- | @compactSVDTol r@ is similar to 'compactSVD' (for which @r=1@), but uses tolerance @tol=r*g*eps*(max rows cols)@ to distinguish nonzero singular values, where @g@ is the greatest singular value. If @g<r*eps@, then only one singular value is returned.
 compactSVDTol :: Field t  => Double -> Matrix t -> (Matrix t, Vector Double, Matrix t)
 compactSVDTol r m = (u', subVector 0 d s, v') where
     (u,s,v) = thinSVD m

--- a/packages/base/src/Internal/Vector.hs
+++ b/packages/base/src/Internal/Vector.hs
@@ -62,6 +62,7 @@ ti = fromIntegral
 -- | Number of elements
 dim :: (Storable t) => Vector t -> Int
 dim = Vector.length
+{-# INLINE dim #-}
 
 
 -- C-Haskell vector adapter
@@ -139,6 +140,7 @@ subVector :: Storable t => Int       -- ^ index of the starting element
                         -> Vector t  -- ^ source
                         -> Vector t  -- ^ result
 subVector = Vector.slice
+{-# INLINE subVector #-}
 
 
 


### PR DESCRIPTION
Clarify compactSVDTol corner case in documentation and inline dim and subVector since these are inlined by the vector package.