### PR TITLE
Add disable-default-paths flags for hermetic builds

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -31,6 +31,11 @@ flag openblas
     default:        False
     manual: True
 
+flag disable-default-paths
+    description:    When enabled, don't add default hardcoded include/link dirs by default. Needed for hermetic builds like in nix.
+    default:        False
+    manual: True
+
 library
 
     Build-Depends:      base >= 4.8 && < 5,
@@ -95,29 +100,33 @@ library
 
     if os(OSX)
         if flag(openblas)
-            extra-lib-dirs:     /opt/local/lib/openblas/lib
+            if !flag(disable-default-paths)
+                extra-lib-dirs:     /opt/local/lib/openblas/lib
             extra-libraries:    openblas
         else
             extra-libraries:    blas lapack
 
-        extra-lib-dirs: /opt/local/lib/
-        include-dirs: /opt/local/include/
-        extra-lib-dirs: /usr/local/lib/
-        include-dirs: /usr/local/include/
+        if !flag(disable-default-paths)
+            extra-lib-dirs: /opt/local/lib/
+            include-dirs: /opt/local/include/
+            extra-lib-dirs: /usr/local/lib/
+            include-dirs: /usr/local/include/
         if arch(i386)
             cc-options: -arch i386
         frameworks: Accelerate
 
     if os(freebsd)
         if flag(openblas)
-            extra-lib-dirs:     /usr/local/lib/openblas/lib
+            if !flag(disable-default-paths)
+                extra-lib-dirs:     /usr/local/lib/openblas/lib
             extra-libraries:    openblas
         else
             extra-libraries:    blas lapack
 
-       extra-lib-dirs: /usr/local/lib
-       include-dirs: /usr/local/include
-       extra-libraries: gfortran
+        if !flag(disable-default-paths)
+            extra-lib-dirs: /usr/local/lib
+            include-dirs: /usr/local/include
+        extra-libraries: gfortran
 
     if os(windows)
         if flag(openblas)
@@ -127,7 +136,8 @@ library
 
     if os(linux)
         if flag(openblas)
-            extra-lib-dirs:     /usr/lib/openblas/lib
+            if !flag(disable-default-paths)
+                extra-lib-dirs:     /usr/lib/openblas/lib
             extra-libraries:    openblas
         else
             extra-libraries:    blas lapack

--- a/packages/glpk/hmatrix-glpk.cabal
+++ b/packages/glpk/hmatrix-glpk.cabal
@@ -22,6 +22,11 @@ extra-source-files:     examples/simplex1.hs
                         examples/simplex4.hs
                         examples/simplex5.hs
 
+flag disable-default-paths
+    description:    When enabled, don't add default hardcoded include/link dirs by default. Needed for hermetic builds like in nix.
+    default:        False
+    manual: True
+
 library
     Build-Depends:      base <5, hmatrix >= 0.17, containers
 
@@ -37,11 +42,12 @@ library
     extra-libraries:    glpk
 
     if os(OSX)
-        extra-lib-dirs: /usr/lib
-        extra-lib-dirs: /opt/local/lib/
-        include-dirs: /opt/local/include/
-        extra-lib-dirs: /usr/local/lib/
-        include-dirs: /usr/local/include/
+        if !flag(disable-default-paths)
+            extra-lib-dirs: /usr/lib
+            extra-lib-dirs: /opt/local/lib/
+            include-dirs: /opt/local/include/
+            extra-lib-dirs: /usr/local/lib/
+            include-dirs: /usr/local/include/
         if arch(i386)
             cc-options: -arch i386
 

--- a/packages/gsl/hmatrix-gsl.cabal
+++ b/packages/gsl/hmatrix-gsl.cabal
@@ -23,6 +23,11 @@ flag onlygsl
     description:    don't link gslcblas
     default:        False
 
+flag disable-default-paths
+    description:    When enabled, don't add default hardcoded include/link dirs by default. Needed for hermetic builds like in nix.
+    default:        False
+    manual: True
+
 library
 
     Build-Depends:      base<5, hmatrix>=0.18, array, vector,
@@ -65,19 +70,21 @@ library
                         -fno-warn-unused-binds
 
     if os(OSX)
-        extra-lib-dirs: /opt/local/lib/
-        include-dirs: /opt/local/include/
-        extra-lib-dirs: /usr/local/lib/
-        include-dirs: /usr/local/include/
+        if !flag(disable-default-paths)
+            extra-lib-dirs: /opt/local/lib/
+            include-dirs: /opt/local/include/
+            extra-lib-dirs: /usr/local/lib/
+            include-dirs: /usr/local/include/
         extra-libraries: gsl
         if arch(i386)
             cc-options: -arch i386
         frameworks: Accelerate
 
     if os(freebsd)
-       extra-lib-dirs: /usr/local/lib
-       include-dirs: /usr/local/include
-       extra-libraries: gsl
+        if !flag(disable-default-paths)
+            extra-lib-dirs: /usr/local/lib
+            include-dirs: /usr/local/include
+        extra-libraries: gsl
 
     if os(windows)
         extra-libraries: gsl-0


### PR DESCRIPTION
[This line](https://github.com/albertoruiz/hmatrix/blob/e7843cb083316bc5b5a760f7c987671505c2e9d8/packages/base/hmatrix.cabal#L130) sets `extra-lib-dirs:     /usr/...` which doesn't make sense on some systems / Linux distributions, or when you want hermetic builds as on [nix](https://github.com/NixOS/cabal2nix/blob/3de0b842700dceff35ab18ace96c58d301bc3b04/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs#L82).

```
    if os(linux)
        if flag(openblas)
            extra-lib-dirs:     /usr/lib/openblas/lib
            extra-libraries:    openblas
        else
            extra-libraries:    blas lapack
```

This PR adds a flag (off by default) to disable the use of these default paths.