### PR TITLE
Fix compilation with GHC 8.2 by adding some type signatures.

### DIFF
--- a/packages/base/src/Internal/Util.hs
+++ b/packages/base/src/Internal/Util.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 
 
@@ -613,6 +614,9 @@ gaussElim_1 x y = dropColumns (rows x) (flipud $ fromRows s2)
     s1 = fromRows $ pivotDown (rows x) 0 rs      -- interesting
     s2 = pivotUp (rows x-1) (toRows $ flipud s1)
 
+pivotDown
+  :: forall t . (Fractional t, Num (Vector t), Ord t, Indexable (Vector t) t, Numeric t)
+  => Int -> Int -> [Vector t] -> [Vector t]
 pivotDown t n xs
     | t == n    = []
     | otherwise = y : pivotDown t (n+1) ys
@@ -622,6 +626,7 @@ pivotDown t n xs
     pivot k = (const k &&& id)
             . sortBy (flip compare `on` (abs. (!k)))
 
+    redu :: (Int, [Vector t]) -> [Vector t]
     redu (k,x:zs)
         | p == 0 = error "gauss: singular!"  -- FIXME
         | otherwise = u : map f zs
@@ -632,12 +637,16 @@ pivotDown t n xs
     redu (_,[]) = []
 
 
+pivotUp
+  :: forall t . (Fractional t, Num (Vector t), Ord t, Indexable (Vector t) t, Numeric t)
+  => Int -> [Vector t] -> [Vector t]
 pivotUp n xs
     | n == -1 = []
     | otherwise = y : pivotUp (n-1) ys
   where
     y:ys = redu' (n,xs)
 
+    redu' :: (Int, [Vector t]) -> [Vector t]
     redu' (k,x:zs) = u : map f zs
       where
         u = x


### PR DESCRIPTION
Fixes this compile error:

```
  src/Internal/Util.hs:625:5: error:
      • Could not deduce (Eq t)
        from the context: (Indexable (c t) a, Indexable (c t) t,
                           Linear t c, Num (c t), Fractional t, Num a, Eq a)
          bound by the inferred type for ‘redu’:
                     forall a t (c :: * -> *).
                     (Indexable (c t) a, Indexable (c t) t, Linear t c, Num (c t),
                      Fractional t, Num a, Eq a) =>
                     (Int, [c t]) -> [c t]
          at src/Internal/Util.hs:(625,5)-(632,20)
      • In the ambiguity check for the inferred type for ‘redu’
        To defer the ambiguity check to use sites, enable AllowAmbiguousTypes
```