### PR TITLE
Provide better error message

### DIFF
--- a/packages/gsl/src/Numeric/GSL/gsl-ode.c
+++ b/packages/gsl/src/Numeric/GSL/gsl-ode.c
@@ -178,11 +178,16 @@ int ode(int method, int control, double h,
            status = gsl_odeiv2_driver_apply (d, &t, ti, y);
      
            if (status != GSL_SUCCESS) {
-         	  printf ("error in ode, return value=%d\n", status);
-         	  break;
-        	}
-
-//           printf ("%.5e %.5e %.5e\n", t, y[0], y[1]);
+             int k;
+             printf ("error in ode, return value=%d\n", status);
+             printf("last successful values are:\n");
+             printf("t = %.5e\n", t);
+             for (k=0; k < xin; k++)
+               {
+                 printf("y[%d] = %.5e\n", k, y[k]);
+               }
+             break;
+           }
            
            for(j=0; j<xin; j++) {
                solp[i*xin + j] = y[j];


### PR DESCRIPTION
The below fails with an error of -1 :( gsl can provide a bit more information: the last value of the solution before the solver fails. This can be quite useful. In the example below, one of the variables grows to ~1e15 having started at ~1e1 suggesting to the modeller that there is probably something wrong with the model.

```
module Main where

import Numeric.AD
import Numeric.LinearAlgebra
import Numeric.GSL

f t [co2, fumerase, fumarate, malate, precursor] =
  [ v_4
  , 0.0
  , v_testName + 4 * v_testName2 - v_3
  , v_3 - v_4
  , (-3) * v_testName - 6 * v_testName2 - v_4
  ]
  where
    v_4 = k_4 * malate * precursor / (co2 + 1)
    k_4 = 1.4945345539252441
    v_testName = test * precursor^3 - k_testName * fumarate
    test = 2.4867483417661203
    k_testName = 2.3031094829563745
    v_testName2 = k_testName * precursor^6
    v_3 = kcat_3 * fumerase * fumarate / (km3 + fumarate)
    km3 = 0.7479676266717306
    kcat_3 = 2.9890691078504883

j :: Double -> Vector Double -> Matrix Double
j t v = (5><5) $ concat $ jacobian (f undefined) (toList v)

g t v = fromList $ f t (toList v)

initCond = fromList [0.420808666641724
                    ,3.6932446017481526
                    ,11.754056074008167
                    ,0.4472415886254433
                    ,0.0]

solTimesOrig, solTimesTest :: Vector Double
solTimesOrig = fromList [0.0,120.0 .. 12000.0]
solTimesTest = fromList [0.0, 0.12 .. 12.0]

initTimeStepOrig = 0.1
initTimeStepTest = 0.01

sol = odeSolveVWith (MSBDF j) (XX' 1.0e-4 1.0e-4 1 1)
                    initTimeStepOrig g initCond solTimesOrig

main = do
  putStrLn $ show sol
```

Example message:

```
error in ode, return value=-1
last successful values are:
t = 1.51899e+01
y[0] = 1.64096e+02
y[1] = 3.69324e+00
y[2] = 3.75543e+15
y[3] = 3.89947e+00
y[4] = 3.51009e+02
*** Exception: ode: code -1
CallStack (from HasCallStack):
  error, called at src/Internal/Devel.hs:51:21 in hmatrix-0.18.1.0-E0yq1w8fECnGkejtKkfm5e:Internal.Devel
```