### PR TITLE
Print errors to stderr

### DIFF
--- a/packages/gsl/src/Numeric/GSL/gsl-ode.c
+++ b/packages/gsl/src/Numeric/GSL/gsl-ode.c
@@ -40,9 +40,9 @@ int ode(int method, int control, double h,
         case 5 : {T = gsl_odeiv_step_rk2imp; break; }
         case 6 : {T = gsl_odeiv_step_rk4imp; break; }
         case 7 : {T = gsl_odeiv_step_bsimp; break; }
-        case 8 : { printf("Sorry: ODE rk1imp not available in this GSL version\n"); exit(0); }
-        case 9 : { printf("Sorry: ODE msadams not available in this GSL version\n"); exit(0); }
-        case 10: { printf("Sorry: ODE msbdf not available in this GSL version\n"); exit(0); }
+        case 8 : { fprintf(stderr,"Sorry: ODE rk1imp not available in this GSL version\n"); exit(0); }
+        case 9 : { fprintf(stderr,"Sorry: ODE msadams not available in this GSL version\n"); exit(0); }
+        case 10: { fprintf(stderr,"Sorry: ODE msbdf not available in this GSL version\n"); exit(0); }
         default: ERROR(BAD_CODE);
     }
 
@@ -180,11 +180,11 @@ int ode(int method, int control, double h,
            if (status != GSL_SUCCESS) {
              int k;
              printf ("error in ode, return value=%d\n", status);
-             printf("last successful values are:\n");
-             printf("t = %.5e\n", t);
+             fprintf(stderr,"last successful values are:\n");
+             fprintf(stderr,"t = %.5e\n", t);
              for (k=0; k < xin; k++)
                {
-                 printf("y[%d] = %.5e\n", k, y[k]);
+                 fprintf(stderr,"y[%d] = %.5e\n", k, y[k]);
                }
              break;
            }

--- a/packages/gsl/src/Numeric/GSL/gsl-ode.c
+++ b/packages/gsl/src/Numeric/GSL/gsl-ode.c
@@ -40,9 +40,9 @@ int ode(int method, int control, double h,
         case 5 : {T = gsl_odeiv_step_rk2imp; break; }
         case 6 : {T = gsl_odeiv_step_rk4imp; break; }
         case 7 : {T = gsl_odeiv_step_bsimp; break; }
-        case 8 : { fprintf(stderr,"Sorry: ODE rk1imp not available in this GSL version\n"); exit(0); }
-        case 9 : { fprintf(stderr,"Sorry: ODE msadams not available in this GSL version\n"); exit(0); }
-        case 10: { fprintf(stderr,"Sorry: ODE msbdf not available in this GSL version\n"); exit(0); }
+        case 8 : { fprintf(stderr, "Sorry: ODE rk1imp not available in this GSL version\n"); exit(0); }
+        case 9 : { fprintf(stderr, "Sorry: ODE msadams not available in this GSL version\n"); exit(0); }
+        case 10: { fprintf(stderr, "Sorry: ODE msbdf not available in this GSL version\n"); exit(0); }
         default: ERROR(BAD_CODE);
     }
 
@@ -179,12 +179,12 @@ int ode(int method, int control, double h,
      
            if (status != GSL_SUCCESS) {
              int k;
-             printf ("error in ode, return value=%d\n", status);
-             fprintf(stderr,"last successful values are:\n");
-             fprintf(stderr,"t = %.5e\n", t);
+             fprintf(stderr, "error in ode, return value=%d\n", status);
+             fprintf(stderr, "last successful values are:\n");
+             fprintf(stderr, "t = %.5e\n", t);
              for (k=0; k < xin; k++)
                {
-                 fprintf(stderr,"y[%d] = %.5e\n", k, y[k]);
+                 fprintf(stderr, "y[%d] = %.5e\n", k, y[k]);
                }
              break;
            }


### PR DESCRIPTION
@albertoruiz

Did you want me to do the same for the other packages?

I noticed this

```
    switch(method) {
        case 0 : {T = gsl_root_fsolver_bisection; printf("7\n"); break; }
        case 1 : {T = gsl_root_fsolver_falsepos; break; }
        case 2 : {T = gsl_root_fsolver_brent; break; }
        default: ERROR(BAD_CODE);
```

Any ideas why there would be a `printf("7\n")` randomly in there?
