### PR TITLE
Workaround for GHC-8.4.x

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -46,6 +46,7 @@ library
                         split,
                         bytestring,
                         storable-complex,
+                        semigroups,
                         vector >= 0.8
 
     hs-source-dirs:     src

--- a/packages/base/src/Internal/Container.hs
+++ b/packages/base/src/Internal/Container.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -29,7 +30,9 @@ import Internal.Matrix
 import Internal.Element
 import Internal.Numeric
 import Internal.Algorithms(Field,linearSolveSVD,Herm,mTm)
-
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 ------------------------------------------------------------------
 
 {- | Creates a real vector containing a range of values:

--- a/packages/base/src/Internal/Convolution.hs
+++ b/packages/base/src/Internal/Convolution.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 -----------------------------------------------------------------------------
 {- |
@@ -23,6 +24,9 @@ import Internal.Numeric
 import Internal.Element
 import Internal.Conversion
 import Internal.Container
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 
 vectSS :: Element t => Int -> Vector t -> Matrix t

--- a/packages/base/src/Internal/Modular.hs
+++ b/packages/base/src/Internal/Modular.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -38,13 +39,20 @@ import Internal.Util(Normed(..),Indexable(..),
                      gaussElim, gaussElim_1, gaussElim_2,
                      luST, luSolve', luPacked', magnit, invershur)
 import Internal.ST(mutable)
+#if MIN_VERSION_base(4,11,0)
+import GHC.TypeLits hiding (Mod)
+#else
 import GHC.TypeLits
+#endif
 import Data.Proxy(Proxy)
 import Foreign.ForeignPtr(castForeignPtr)
 import Foreign.Storable
 import Data.Ratio
 import Data.Complex
 import Control.DeepSeq ( NFData(..) )
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 
 

--- a/packages/base/src/Internal/Util.hs
+++ b/packages/base/src/Internal/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -80,6 +81,9 @@ import Control.Arrow((&&&),(***))
 import Data.Complex
 import Data.Function(on)
 import Internal.ST
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 type ℝ = Double
 type ℕ = Int

--- a/packages/base/src/Numeric/LinearAlgebra.hs
+++ b/packages/base/src/Numeric/LinearAlgebra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 -----------------------------------------------------------------------------
@@ -190,6 +191,9 @@ import Internal.Random
 import Internal.Sparse((!#>))
 import Internal.CG
 import Internal.Conversion
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 {- | dense matrix product
 

--- a/packages/base/src/Numeric/LinearAlgebra/HMatrix.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/HMatrix.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------------------
 {- |
 Module      :  Numeric.LinearAlgebra.HMatrix
@@ -19,6 +20,9 @@ module Numeric.LinearAlgebra.HMatrix (
 import Numeric.LinearAlgebra
 import Internal.Util
 import Internal.Algorithms(cholSH, mbCholSH, eigSH', eigenvaluesSH', geigSH')
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 infixr 8 <·>
 (<·>) :: Numeric t => Vector t -> Vector t -> t

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -80,6 +81,9 @@ import Control.Arrow((***))
 import Text.Printf
 import Data.Type.Equality ((:~:)(Refl))
 import qualified Data.Bifunctor as BF (first)
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 ud1 :: R n -> Vector ℝ
 ud1 (R (Dim v)) = v

--- a/packages/base/src/Numeric/Matrix.hs
+++ b/packages/base/src/Numeric/Matrix.hs
@@ -32,7 +32,10 @@ import Internal.Element
 import Internal.Numeric
 import qualified Data.Monoid as M
 import Data.List(partition)
+import qualified Data.Foldable as F
+import qualified Data.Semigroup as S
 import Internal.Chain
+
 
 -------------------------------------------------------------------
 
@@ -83,6 +86,11 @@ adaptScalarM f1 f2 f3 x y
     | isScalar x = f1   (x @@>(0,0) ) y
     | isScalar y = f3 x (y @@>(0,0) )
     | otherwise = f2 x y
+
+instance (Container Vector t, Eq t, Num (Vector t), Product t) => S.Semigroup (Matrix t)
+  where
+    (<>) = mappend
+    sconcat = mconcat . F.toList
 
 instance (Container Vector t, Eq t, Num (Vector t), Product t) => M.Monoid (Matrix t)
   where

--- a/packages/gsl/src/Numeric/GSL/Fitting.hs
+++ b/packages/gsl/src/Numeric/GSL/Fitting.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 {- |
@@ -58,6 +59,9 @@ import Numeric.GSL.Internal
 import Foreign.Ptr(FunPtr, freeHaskellFunPtr)
 import Foreign.C.Types
 import System.IO.Unsafe(unsafePerformIO)
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 -------------------------------------------------------------------------
 

--- a/packages/gsl/src/Numeric/GSL/Random.hs
+++ b/packages/gsl/src/Numeric/GSL/Random.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Numeric.GSL.Random
@@ -30,7 +31,9 @@ import Numeric.LinearAlgebra.HMatrix hiding (
     randn
     )
 import System.Random(randomIO)
-
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 type Seed = Int
 

--- a/packages/tests/src/Numeric/LinearAlgebra/Tests.hs
+++ b/packages/tests/src/Numeric/LinearAlgebra/Tests.hs
@@ -39,7 +39,11 @@ import Numeric.LinearAlgebra.Tests.Properties
 import Test.HUnit hiding ((~:),test,Testable,State)
 import System.Info
 import Data.List(foldl1')
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((^),(<>))
+#else
 import Prelude hiding ((^))
+#endif
 import qualified Prelude
 import System.CPUTime
 import System.Exit

--- a/packages/tests/src/Numeric/LinearAlgebra/Tests/Instances.hs
+++ b/packages/tests/src/Numeric/LinearAlgebra/Tests/Instances.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, UndecidableInstances, FlexibleInstances, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, FlexibleContexts, UndecidableInstances, FlexibleInstances, ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 {- |
 Module      :  Numeric.LinearAlgebra.Tests.Instances
@@ -32,7 +32,9 @@ import Test.QuickCheck(Arbitrary,arbitrary,choose,vector,sized,shrink)
 import GHC.TypeLits
 import Data.Proxy (Proxy(..))
 import qualified Numeric.LinearAlgebra.Static as Static
-
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 shrinkListElementwise :: (Arbitrary a) => [a] -> [[a]]
 shrinkListElementwise []     = []

--- a/packages/tests/src/Numeric/LinearAlgebra/Tests/Properties.hs
+++ b/packages/tests/src/Numeric/LinearAlgebra/Tests/Properties.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
@@ -58,6 +59,9 @@ import Data.Binary
 import Data.Binary.Get (runGet)
 import Data.Either (isLeft)
 import Debug.Trace (traceShowId)
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 (~=) :: Double -> Double -> Bool
 a ~= b = abs (a - b) < 1e-10


### PR DESCRIPTION
GHC-8.4.1-alpha1 had been released, and there is some conflicting API changes there.
This pull request resolves such conflicts:

* Adds missing Semigroup instances
* Adds `semigroups` to the deps of `hmatrix`
* Hides conflicting names from import list with base >= 4.11
    * `(Prelude.<>)` and `GHC.TypeNats.Mod`