### PR TITLE
GSL.ODE: free the jacobian after use

### DIFF
--- a/packages/gsl/src/Numeric/GSL/ODE.hs
+++ b/packages/gsl/src/Numeric/GSL/ODE.hs
@@ -152,6 +152,7 @@ odeSolveVWith' method mbjac control epsAbs epsRel aX aX' mbsc h f xiv ts =
                 // sc' // xiv' // ts' )
                 "ode"
         freeHaskellFunPtr fp
+        if (jp /= nullFunPtr) then freeHaskellFunPtr jp else pure ()
         return sol
 
 foreign import ccall safe "ode"


### PR DESCRIPTION
When calling the function `Numeric.GSL.ODE.odeSolveVWith'` and provide a
jacobian, a pointer to this jacobian is registered, but never freed, which causes a memory leak.

https://github.com/albertoruiz/hmatrix/blob/8cb879a4ad83656bc70652957a08113e2b784886/packages/gsl/src/Numeric/GSL/ODE.hs#L146-L148
This PR adds a call to `freeHaskellFunPtr` when needed at the end
of the function to fix this.